### PR TITLE
Create script that generates comma-separated results for multiple window sizes

### DIFF
--- a/datagrump/controller.cc
+++ b/datagrump/controller.cc
@@ -6,15 +6,15 @@
 using namespace std;
 
 /* Default constructor */
-Controller::Controller( const bool debug )
-  : debug_( debug )
+Controller::Controller( const uint window_size, const bool debug )
+  : debug_( debug ), window_size_( window_size )
 {}
 
 /* Get current window size, in datagrams */
 unsigned int Controller::window_size()
 {
   /* Default: fixed window size of 100 outstanding datagrams */
-  unsigned int the_window_size = 50;
+  unsigned int the_window_size = window_size_;
 
   if ( debug_ ) {
     cerr << "At time " << timestamp_ms()

--- a/datagrump/controller.hh
+++ b/datagrump/controller.hh
@@ -9,6 +9,7 @@ class Controller
 {
 private:
   bool debug_; /* Enables debugging output */
+  uint window_size_; /* fixed window size */
 
   /* Add member variables here */
 
@@ -18,7 +19,7 @@ public:
      the call site as well (in sender.cc) */
 
   /* Default constructor */
-  Controller( const bool debug );
+  Controller( const uint window_size, const bool debug );
 
   /* Get current window size, in datagrams */
   unsigned int window_size();

--- a/datagrump/exercise-A-throughput-graph
+++ b/datagrump/exercise-A-throughput-graph
@@ -1,0 +1,225 @@
+#!/usr/bin/env perl
+
+use warnings;
+use strict;
+use POSIX;
+
+sub usage
+{
+  die qq{Usage: $0 MS_PER_BIN [filename]\n};
+}
+
+if ( scalar @ARGV < 1 or scalar @ARGV > 2 ) {
+  usage;
+}
+
+my $MS_PER_BIN = shift;
+
+if ( $MS_PER_BIN !~ m{^\d+$} ) {
+  usage;
+}
+
+sub ms_to_bin {
+  return int( $_[0] / $MS_PER_BIN );
+}
+
+sub bin_to_seconds {
+  return sprintf q{%.3f}, $_[0] * $MS_PER_BIN / 1000.0;
+}
+
+my ( %capacity, %arrivals, %departures );
+
+my $first_timestamp = undef;
+my $last_timestamp = undef;
+my $base_timestamp = undef;
+my $capacity_sum;
+my $arrival_sum;
+my $departure_sum;
+my @delays;
+my %signal_delay;
+
+LINE: while ( <> ) {
+  chomp;
+
+  if ( m{^# base timestamp: (\d+)} ) {
+    if ( defined $base_timestamp ) {
+      die "base timestamp multiply defined";
+    } else {
+      $base_timestamp = $1;
+    }
+    next LINE;
+  } elsif ( m{^#} ) {
+    next LINE;
+  }
+
+  # parse and validate line
+  my ( $timestamp, $event_type, $num_bytes, $delay ) = split /\s+/, $_;
+
+  if ( not defined $num_bytes ) {
+    die q{Format: timestamp event_type num_bytes [delay]};
+  }
+
+  if ( $timestamp !~ m{^\d+$} ) {
+    die qq{Invalid timestamp: $timestamp};
+  }
+
+  if ( $num_bytes !~ m{^\d+$} ) {
+    die qq{Invalid byte count: $num_bytes};
+  }
+
+  if ( not defined $base_timestamp ) {
+    die "logfile is missing base timestamp";
+  }
+
+  $timestamp -= $base_timestamp; # correct for startup time variation
+
+  if ( not defined $last_timestamp ) {
+    $last_timestamp = $first_timestamp = $timestamp;
+  }
+
+  $last_timestamp = max( $timestamp, $last_timestamp );
+
+  my $num_bits = $num_bytes * 8;
+  my $bin = ms_to_bin( $timestamp );
+
+  # process the event
+  if ( $event_type eq q{+} ) {
+    $arrivals{ $bin } += $num_bits;
+    $arrival_sum += $num_bits;
+  } elsif ( $event_type eq q{#} ) {
+    $capacity{ $bin } += $num_bits;
+    $capacity_sum += $num_bits;
+  } elsif ( $event_type eq q{-} ) {
+    if ( not defined $delay ) {
+      die q{Departure format: timestamp - num_bytes delay};
+    }
+    $departures{ $bin } += $num_bits;
+
+    if ( $delay < 0 ) {
+    die qq{Invalid delay: $delay};
+    }
+
+    if ( $timestamp - $delay < 0 ) {
+    die qq{Invalid timestamp and delay: ts=$timestamp, delay=$delay};
+    }
+
+    push @delays, $delay;
+    $departure_sum += $num_bits;
+
+    $signal_delay{ $timestamp - $delay } = min( $delay,
+                        (defined $signal_delay{ $timestamp - $delay })
+                        ? $signal_delay{ $timestamp - $delay }
+                        : POSIX::DBL_MAX );
+  } else {
+    die qq{Unknown event type: $event_type};
+  }
+}
+
+sub min {
+  my $minval = POSIX::DBL_MAX;
+
+  for ( @_ ) {
+    if ( $_ < $minval ) {
+      $minval = $_;
+    }
+  }
+
+  return $minval;
+}
+
+sub max {
+  my $maxval = - POSIX::DBL_MAX;
+
+  for ( @_ ) {
+    if ( $_ > $maxval ) {
+      $maxval = $_;
+    }
+  }
+
+  return $maxval;
+}
+
+if ( not defined $first_timestamp ) {
+    die q{Must have at least one event};
+}
+
+# calculate statistics
+my $duration = ($last_timestamp - $first_timestamp) / 1000.0;
+my $average_capacity = ($capacity_sum / $duration) / 1000000.0;
+my $average_ingress = ($arrival_sum / $duration) / 1000000.0;
+my $average_throughput = ($departure_sum / $duration) / 1000000.0;
+
+if ( scalar @delays == 0 ) {
+  die q{Must have at least one departure event};
+}
+
+@delays = sort { $a <=> $b } @delays;
+
+my $pp95 = $delays[ 0.95 * scalar @delays ];
+
+# measure signal delay every millisecond
+# = minimum time for a message created at time t to get to receiver
+my @signal_delay_samples = sort { $a <=> $b } keys %signal_delay;
+
+for ( my $ts = $signal_delay_samples[ -1 ]; $ts >= $signal_delay_samples[ 0 ]; $ts-- ) {
+  if ( not defined $signal_delay{ $ts } ) {
+    $signal_delay{ $ts } = $signal_delay{ $ts + 1 } + 1;
+  }
+}
+
+my @signal_delays = sort { $a <=> $b } values %signal_delay;
+my $pp95s = $signal_delays[ 0.95 * scalar @signal_delays ];
+
+# avg capacity | avg throughput | utilization | 95th percentile per-packet queueing delay | 95th percentile signal delay
+printf STDERR qq{%.2f, }, $average_capacity;
+printf STDERR qq{%.2f, %.1f%%, }, $average_throughput, 100.0 * $average_throughput / $average_capacity;
+printf STDERR qq{%.0f, }, $pp95;
+printf STDERR qq{%.0f\n}, $pp95s;
+
+# make graph
+my $earliest_bin = min( keys %arrivals, keys %capacity, keys %departures );
+my $latest_bin = max( keys %arrivals, keys %capacity, keys %departures );
+
+if ( $earliest_bin == $latest_bin ) {
+  die q{MS_PER_BIN is too large for length of trace};
+}
+
+my $current_buffer_occupancy = 0;
+
+sub default {
+  return defined $_[ 0 ] ? $_[ 0 ] : 0;
+}
+
+open GNUPLOT, q{| gnuplot} or die;
+
+print GNUPLOT <<END;
+set xlabel "time (s)"
+set ylabel "throughput (Mbits/s)"
+set key center outside top horizontal
+set style fill solid 0.2 noborder
+set terminal svg size 1024,560 fixed  fname 'Arial'  fsize 12 rounded solid mouse standalone name "Throughput"
+set output "/dev/stdout"
+END
+
+printf GNUPLOT qq{plot [%f:%f] "-" using 1:2 title "Capacity (mean %.2f Mbits/s)" with filledcurves above x1 lw 0.5, "-" using 1:3 with lines lc rgb "#0020a0" lw 4 title "Traffic ingress (mean %.2f Mbits/s)", "-" using 1:4 with lines lc rgb "#ff6040" lw 2 title "Traffic egress (mean %.2f Mbits/s)"\n},
+  $first_timestamp / 1000.0, $last_timestamp / 1000.0, $average_capacity, $average_ingress, $average_throughput;
+
+my $output;
+
+for ( my $bin = $earliest_bin; $bin <= $latest_bin; $bin++ ) {
+    my $t = bin_to_seconds( $bin );
+    my ( $cap, $arr, $dep ) = map { (default $_) / ($MS_PER_BIN / 1000.0) / 1000000.0 } ( $capacity{ $bin }, $arrivals{ $bin }, $departures{ $bin } );
+
+    $current_buffer_occupancy += default $arrivals{ $bin };
+    $current_buffer_occupancy -= default $departures{ $bin };
+
+    $output .= qq{$t $cap $arr $dep $current_buffer_occupancy\n};
+}
+
+print GNUPLOT $output;
+print GNUPLOT qq{\ne\n};
+print GNUPLOT $output;
+print GNUPLOT qq{\ne\n};
+print GNUPLOT $output;
+
+close GNUPLOT or die qq{$!};

--- a/datagrump/receiver.cc
+++ b/datagrump/receiver.cc
@@ -29,7 +29,7 @@ int main( int argc, char *argv[] )
   /* "bind" the socket to the user-specified local port number */
   socket.bind( Address( "::0", argv[ 1 ] ) );
 
-  cerr << "Listening on " << socket.local_address().to_string() << endl;
+  // cerr << "Listening on " << socket.local_address().to_string() << endl;
 
   uint64_t sequence_number = 0;
 

--- a/datagrump/run-A
+++ b/datagrump/run-A
@@ -1,0 +1,50 @@
+#!/usr/bin/perl -w
+
+use strict;
+use LWP::UserAgent;
+use HTTP::Request::Common;
+
+for( my $window_size = 1; $window_size <= 3; $window_size = $window_size + 1 ) {
+
+    my $receiver_pid = fork;
+
+    if ( $receiver_pid < 0 ) {
+      die qq{$!};
+    } elsif ( $receiver_pid == 0 ) {
+      # child
+      exec q{./receiver 9090} or die qq{$!};
+    }
+
+    chomp( my $prefix = qx{dirname `which mm-link`} );
+    my $tracedir = $prefix . q{/../share/mahimahi/traces};
+
+    # run the sender inside a linkshell and a delayshell
+    my @command = qw{mm-delay 20 mm-link UPLINK DOWNLINK};
+
+    # display livegraphs if we seem to be running under X
+    if ( defined $ENV{ 'DISPLAY' } ) {
+      push @command, qw{--meter-uplink --meter-uplink-delay};
+    }
+
+    push @command, qw{--once --uplink-log=/tmp/contest_uplink_log -- bash -c};
+
+    push @command, qq{./sender \$MAHIMAHI_BASE 9090 $window_size};
+
+    # for the contest, we will send data over Verizon's downlink
+    # (datagrump sender's uplink)
+    die unless $command[ 3 ] eq "UPLINK";
+    $command[ 3 ] = qq{$tracedir/Verizon-LTE-short.down};
+
+    die unless $command[ 4 ] eq "DOWNLINK";
+    $command[ 4 ] = qq{$tracedir/Verizon-LTE-short.up};
+
+    system @command;
+
+    # kill the receiver
+    kill 'INT', $receiver_pid;
+
+    # analyze performance locally
+    printf STDERR "$window_size, "; # will print window_size, stats
+    system q{./exercise-A-throughput-graph 500 /tmp/contest_uplink_log > /dev/null}
+      and die q{exercise-A-throughput-graph exited with error. NOT uploading};
+}

--- a/datagrump/run-A
+++ b/datagrump/run-A
@@ -4,8 +4,7 @@ use strict;
 use LWP::UserAgent;
 use HTTP::Request::Common;
 
-for( my $window_size = 1; $window_size <= 3; $window_size = $window_size + 1 ) {
-
+for( my $window_size = 1; $window_size <= 1424; $window_size = $window_size + 50 ) {
     my $receiver_pid = fork;
 
     if ( $receiver_pid < 0 ) {

--- a/datagrump/sender.cc
+++ b/datagrump/sender.cc
@@ -31,7 +31,7 @@ private:
 
 public:
   DatagrumpSender( const char * const host, const char * const port,
-		   const bool debug );
+		   const uint window_size, const bool debug );
   int loop();
 };
 
@@ -43,9 +43,9 @@ int main( int argc, char *argv[] )
   }
 
   bool debug = false;
-  if ( argc == 4 and string( argv[ 3 ] ) == "debug" ) {
+  if ( argc == 5 and string( argv[ 4 ] ) == "debug" ) {
     debug = true;
-  } else if ( argc == 3 ) {
+  } else if ( argc == 4 || argc == 3 ) {
     /* do nothing */
   } else {
     cerr << "Usage: " << argv[ 0 ] << " HOST PORT [debug]" << endl;
@@ -54,15 +54,16 @@ int main( int argc, char *argv[] )
 
   /* create sender object to handle the accounting */
   /* all the interesting work is done by the Controller */
-  DatagrumpSender sender( argv[ 1 ], argv[ 2 ], debug );
+  DatagrumpSender sender( argv[ 1 ], argv[ 2 ], atoi(argv[ 3 ]), debug );
   return sender.loop();
 }
 
 DatagrumpSender::DatagrumpSender( const char * const host,
 				  const char * const port,
+          const uint window_size,
 				  const bool debug )
   : socket_(),
-    controller_( debug ),
+    controller_( window_size, debug ),
     sequence_number_( 0 ),
     next_ack_expected_( 0 )
 {
@@ -72,7 +73,7 @@ DatagrumpSender::DatagrumpSender( const char * const host,
   /* connect socket to the remote host */
   /* (note: this doesn't send anything; it just tags the socket
      locally with the remote address */
-  socket_.connect( Address( host, port ) );  
+  socket_.connect( Address( host, port ) );
 
   cerr << "Sending to " << socket_.peer_address().to_string() << endl;
 }


### PR DESCRIPTION
Adds a parameter to the controller and command-line argument to the sender with a fixed window-size.

Modify line 7 of `run-A`  to the desired range of window sizes. Then, running ./run-A &> results.csv should generate a comma-separated value file of `window_size, avg capacity, avg throughput, utilization, 95th percentile per-packet queueing delay, 95th percentile signal delay`. We can import this into [this spreadsheet](https://docs.google.com/spreadsheets/d/1l_t-ILGGy6dAyQiS1vzPXzJuxL6Q1mEvEtQeRHwqns0/edit#gid=0) to create the graph.